### PR TITLE
disable auto-reboots for Drone VM

### DIFF
--- a/.ansible/inventory/production/hosts
+++ b/.ansible/inventory/production/hosts
@@ -8,6 +8,7 @@ all:
     drone:
       hosts:
         drone.diesel.net:
+          auto_reboots: no
 
     tools:
       hosts:


### PR DESCRIPTION
Drone needs to remain up, since it facilitates all the currently running jobs. Safer to reboot this VM manually when needed.