### PR TITLE
Patch ansible-role-ubuntu

### DIFF
--- a/.ansible/roles/requirements.yaml
+++ b/.ansible/roles/requirements.yaml
@@ -8,7 +8,7 @@ roles:
 - name: ubuntu
   scm: git
   src: "git@github.com:Diesel-Net/ansible-role-ubuntu.git"
-  version: 3.0.0
+  version: 3.0.1
 
 - name: docker
   scm: git


### PR DESCRIPTION
- Install CA Certs earlier in the bootstrapping process